### PR TITLE
fix: dimension conflict in xDiT

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you develop/use HunyuanVideo-I2V in your projects, welcome to let us know.
 
 - ComfyUI-Kijai (FP8 Inference, V2V and IP2V Generation): [ComfyUI-HunyuanVideoWrapper](https://github.com/kijai/ComfyUI-HunyuanVideoWrapper) by [Kijai](https://github.com/kijai)
 - HunyuanVideoGP (GPU Poor version): [HunyuanVideoGP](https://github.com/deepbeepmeep/HunyuanVideoGP) by [DeepBeepMeep](https://github.com/deepbeepmeep)
-- xDiT compatibility improvement: [xDiT compatibility improvement](https://github.com/Tencent/HunyuanVideo-I2V/issues/36#issuecomment-2728068507) by [pftq](https://github.com/pftq)
+- xDiT compatibility improvement: [xDiT compatibility improvement](https://github.com/Tencent/HunyuanVideo-I2V/issues/36#issuecomment-2728068507) by [pftq](https://github.com/pftq) and [xibosun](https://github.com/xibosun)
 
 ## 📑 Open-source Plan
 - HunyuanVideo-I2V (Image-to-Video Model)
@@ -380,7 +380,8 @@ For example, to generate a video with 8 GPUs, you can use the following command:
 ```bash
 cd HunyuanVideo-I2V
 
-torchrun --nproc_per_node=8 sample_image2video.py \
+ALLOW_RESIZE_FOR_SP=1 torchrun --nproc_per_node=8 \
+    sample_image2video.py \
     --model HYVideo-T/2 \
     --prompt "An Asian man with short hair in black tactical uniform and white clothes waves a firework stick." \
     --i2v-mode \
@@ -395,44 +396,14 @@ torchrun --nproc_per_node=8 sample_image2video.py \
     --embedded-cfg-scale 6.0 \
     --save-path ./results \
     --ulysses-degree 8 \
-    --ring-degree 1 \
-    --video-size 1280 720 \
-    --xdit-adaptive-size
+    --ring-degree 1
 ```
 
-You can change the `--ulysses-degree` and `--ring-degree` to control the parallel configurations for the best performance. 
-Note that you need to set `--video-size` since xDiT's acceleration mechanism has requirements for the size of the video to be generated.
-To prevent black padding after converting the original image height/width to the target height/width, you can use `--xdit-adaptive-size`.
-The valid parallel configurations are shown in the following table.
+The number of GPUs equals the product of `--ulysses-degree` and `--ring-degree.` Feel free to adjust these parallel configurations to optimize performance.
 
-<details>
-<summary>Supported Parallel Configurations (Click to expand)</summary>
+xDiT divides the video in the latent space based on either the height or width dimension, depending on which one is divisible by the number of GPUs. Enabling `ALLOW_RESIZE_FOR_SP=1` permits xDiT to slightly adjust the input image size so that the height or width is divisible by the number of GPUs.
 
-|     --video-size     | --video-length | --ulysses-degree x --ring-degree | --nproc_per_node |
-|----------------------|----------------|----------------------------------|------------------|
-| 1280 720 or 720 1280 | 129            | 8x1,4x2,2x4,1x8                  | 8                |
-| 1280 720 or 720 1280 | 129            | 1x5                              | 5                |
-| 1280 720 or 720 1280 | 129            | 4x1,2x2,1x4                      | 4                |
-| 1280 720 or 720 1280 | 129            | 3x1,1x3                          | 3                |
-| 1280 720 or 720 1280 | 129            | 2x1,1x2                          | 2                |
-| 1104 832 or 832 1104 | 129            | 4x1,2x2,1x4                      | 4                |
-| 1104 832 or 832 1104 | 129            | 3x1,1x3                          | 3                |
-| 1104 832 or 832 1104 | 129            | 2x1,1x2                          | 2                |
-| 960 960              | 129            | 6x1,3x2,2x3,1x6                  | 6                |
-| 960 960              | 129            | 4x1,2x2,1x4                      | 4                |
-| 960 960              | 129            | 3x1,1x3                          | 3                |
-| 960 960              | 129            | 1x2,2x1                          | 2                |
-| 960 544 or 544 960   | 129            | 6x1,3x2,2x3,1x6                  | 6                |
-| 960 544 or 544 960   | 129            | 4x1,2x2,1x4                      | 4                |
-| 960 544 or 544 960   | 129            | 3x1,1x3                          | 3                |
-| 960 544 or 544 960   | 129            | 1x2,2x1                          | 2                |
-| 832 624 or 624 832   | 129            | 4x1,2x2,1x4                      | 4                |
-| 624 832 or 624 832   | 129            | 3x1,1x3                          | 3                |
-| 832 624 or 624 832   | 129            | 2x1,1x2                          | 2                |
-| 720 720              | 129            | 1x5                              | 5                |
-| 720 720              | 129            | 3x1,1x3                          | 3                |
-
-</details>
+The speedup of parallel inference is shown as follows.
 
 
 <p align="center">

--- a/README_zh.md
+++ b/README_zh.md
@@ -67,7 +67,7 @@
 
 - ComfyUI (支持FP8推理、V2V和IP2V生成): [ComfyUI-HunyuanVideoWrapper](https://github.com/kijai/ComfyUI-HunyuanVideoWrapper) by [Kijai](https://github.com/kijai)
 - HunyuanVideoGP (针对低性能GPU的版本): [HunyuanVideoGP](https://github.com/deepbeepmeep/HunyuanVideoGP) by [DeepBeepMeep](https://github.com/deepbeepmeep)
-- xDiT 兼容性改进: [兼容性改进](https://github.com/Tencent/HunyuanVideo-I2V/issues/36#issuecomment-2728068507) by [pftq](https://github.com/pftq)
+- xDiT 兼容性改进: [兼容性改进](https://github.com/Tencent/HunyuanVideo-I2V/issues/36#issuecomment-2728068507) by [pftq](https://github.com/pftq) and [xibosun](https://github.com/xibosun)
 
 ## 📑 开源计划
 - HunyuanVideo-I2V（图像到视频模型）
@@ -359,7 +359,8 @@ python3 sample_image2video.py \
 ```bash
 cd HunyuanVideo-I2V
 
-torchrun --nproc_per_node=8 sample_image2video.py \
+ALLOW_RESIZE_FOR_SP=1 torchrun --nproc_per_node=8 \
+    sample_image2video.py \
     --model HYVideo-T/2 \
     --prompt "An Asian man with short hair in black tactical uniform and white clothes waves a firework stick." \
     --i2v-mode \
@@ -374,44 +375,14 @@ torchrun --nproc_per_node=8 sample_image2video.py \
     --embedded-cfg-scale 6.0 \
     --save-path ./results \
     --ulysses-degree 8 \
-    --ring-degree 1 \
-    --video-size 1280 720 \
-    --xdit-adaptive-size
+    --ring-degree 1
 ```
 
-可以配置`--ulysses-degree`和`--ring-degree`来控制并行配置，
-注意，你需要设置 `--video-size`，因为 xDiT 的加速机制对要生成的视频的长宽有要求。
-为了防止将原始图像高度/宽度转换为目标高度/宽度后出现黑色填充，你可以使用 `--xdit-adaptive-size`。
-具体的可选参数如下。
+GPU 的数量等于 `--ulysses-degree` 与 `--ring-degree` 的乘积。您可以更改这些并行配置以获得最佳性能。
 
-<details>
-<summary>支持的并行配置 (点击查看详情)</summary>
+xDiT 在潜在空间中根据高度或宽度维度对视频进行分割，具体取决于哪个维度可以被 GPU 数量整除。设置 `ALLOW_RESIZE_FOR_SP=1` 允许 xDiT 稍微调整输入图像的大小，以使高度或宽度可以被GPU数量整除。
 
-|     --video-size     | --video-length | --ulysses-degree x --ring-degree | --nproc_per_node |
-|----------------------|----------------|----------------------------------|------------------|
-| 1280 720 或 720 1280 | 129            | 8x1,4x2,2x4,1x8                  | 8                |
-| 1280 720 或 720 1280 | 129            | 1x5                              | 5                |
-| 1280 720 或 720 1280 | 129            | 4x1,2x2,1x4                      | 4                |
-| 1280 720 或 720 1280 | 129            | 3x1,1x3                          | 3                |
-| 1280 720 或 720 1280 | 129            | 2x1,1x2                          | 2                |
-| 1104 832 或 832 1104 | 129            | 4x1,2x2,1x4                      | 4                |
-| 1104 832 或 832 1104 | 129            | 3x1,1x3                          | 3                |
-| 1104 832 或 832 1104 | 129            | 2x1,1x2                          | 2                |
-| 960 960              | 129            | 6x1,3x2,2x3,1x6                  | 6                |
-| 960 960              | 129            | 4x1,2x2,1x4                      | 4                |
-| 960 960              | 129            | 3x1,1x3                          | 3                |
-| 960 960              | 129            | 1x2,2x1                          | 2                |
-| 960 544 或 544 960   | 129            | 6x1,3x2,2x3,1x6                  | 6                |
-| 960 544 或 544 960   | 129            | 4x1,2x2,1x4                      | 4                |
-| 960 544 或 544 960   | 129            | 3x1,1x3                          | 3                |
-| 960 544 或 544 960   | 129            | 1x2,2x1                          | 2                |
-| 832 624 或 624 832   | 129            | 4x1,2x2,1x4                      | 4                |
-| 624 832 或 624 832   | 129            | 3x1,1x3                          | 3                |
-| 832 624 或 624 832   | 129            | 2x1,1x2                          | 2                |
-| 720 720              | 129            | 1x5                              | 5                |
-| 720 720              | 129            | 3x1,1x3                          | 3                |
-
-</details>
+xDiT 并行推理加速如下表所示。
 
 <p align="center">
 <table align="center">

--- a/hyvideo/config.py
+++ b/hyvideo/config.py
@@ -575,11 +575,6 @@ def add_parallel_args(parser: argparse.ArgumentParser):
         default=1,
         help="Ring degree for xdit parallel args.",
     )
-    group.add_argument(
-        "--xdit-adaptive-size",
-        action="store_true",
-        help="Make the generated video has no black padding.")
-
 
     return parser
 

--- a/sample_image2video.py
+++ b/sample_image2video.py
@@ -49,7 +49,6 @@ def main():
         i2v_stability=args.i2v_stability,
         ulysses_degree=args.ulysses_degree,
         ring_degree=args.ring_degree,
-        xdit_adaptive_size=args.xdit_adaptive_size
     )
     samples = outputs['samples']
     


### PR DESCRIPTION
This pull request addresses the issues reported in https://github.com/Tencent/HunyuanVideo-I2V/issues/35 and https://github.com/Tencent/HunyuanVideo-I2V/issues/41.

The PR resolves the dimension mismatch problem between the input image and the specified `--video-size` in xDiT parallel inference. With this update, when in i2v mode, the video generation process now focuses solely on the dimensions of the input image, ignoring the `--video-size` parameter.

Given that the input image's height or width may not evenly divide by the number of GPUs during parallel inference, we have introduced an `ALLOW_RESIZE_FOR_SP=1` environment variable. This setting allows xDiT to make slight adjustments to the input image size, ensuring that the height or width aligns with the number of GPUs for parallel inference.

The updated command for parallel inference is shown as below, which can also be found in the updated readme.

```bash
 cd HunyuanVideo-I2V

 ALLOW_RESIZE_FOR_SP=1 torchrun --nproc_per_node=8 \
    sample_image2video.py \
    --model HYVideo-T/2 \
    --prompt "An Asian man with short hair in black tactical uniform and white clothes waves a firework stick." \
    --i2v-mode \
    --i2v-image-path ./assets/demo/i2v/imgs/0.jpg \
    --i2v-resolution 720p \
    --i2v-stability \
    --infer-steps 50 \
    --video-length 129 \
    --flow-reverse \
    --flow-shift 7.0 \
    --seed 0 \
    --embedded-cfg-scale 6.0 \
    --save-path ./results \
    --ulysses-degree 8 \
    --ring-degree 1
```